### PR TITLE
Add some missing functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,11 @@ impl PublicKey {
         bytes.copy_from_slice(self.0.into_affine().into_compressed().as_ref());
         bytes
     }
+
+    /// Generates a non-redacted debug string.
+    pub fn reveal(&self) -> String {
+        format!("PublicKey({:?})", self.0)
+    }
 }
 
 /// A public key share.
@@ -877,6 +882,7 @@ mod tests {
         let sk_bob: SecretKey = random();
         let sk_eve: SecretKey = random();
         let pk_bob = sk_bob.public_key();
+        println!("pk_bob = {}", pk_bob.reveal());
         let msg = b"Muffins in the canteen today! Don't tell Eve!";
         let ciphertext = pk_bob.encrypt(&msg[..]);
         assert!(ciphertext.verify());

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -581,6 +581,15 @@ impl BivarPoly {
         })
     }
 
+    /// Creates a polynomial where the 0th coeff is set to `secret`.
+    pub fn with_secret<T: IntoFr, R: Rng>(secret: T, degree: usize, rng: &mut R) -> Self {
+        let mut bipoly: BivarPoly = BivarPoly::random(degree, rng);
+        let mut coeff = bipoly.coeff.clone();
+        coeff[0] = secret.into_fr();
+        bipoly.coeff = coeff;
+        bipoly
+    }
+
     /// Creates a random polynomial.
     pub fn try_random<R: Rng>(degree: usize, rng: &mut R) -> Result<Self> {
         let len = coeff_pos(degree, degree)
@@ -817,6 +826,15 @@ mod tests {
         }
         let interp = Poly::interpolate(samples);
         assert_eq!(interp, poly);
+    }
+
+    #[test]
+    fn bipoly_with_secret() {
+        let mut rng = rand::thread_rng();
+        let degree: usize = 3;
+        let secret: u64 = 42;
+        let bipoly_with_secret = BivarPoly::with_secret(secret, degree, &mut rng);
+        assert_eq!(secret.into_fr(), bipoly_with_secret.coeff[0])
     }
 
     #[test]

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -513,6 +513,11 @@ impl Commitment {
         let len = self.coeff.len() - zeros;
         self.coeff.truncate(len)
     }
+
+    /// Generates a non-redacted debug string
+    pub fn reveal(&self) -> String {
+        format!("Commitment {{ coeff: {:?} }}", self.coeff)
+    }
 }
 
 /// A symmetric bivariate polynomial in the prime field.
@@ -728,6 +733,16 @@ impl BivarCommitment {
     /// Returns the `0`-th to `degree`-th power of `x`.
     fn powers<T: IntoFr>(&self, x: T) -> Vec<Fr> {
         powers(x, self.degree)
+    }
+
+    /// Generates a non-redacted debug string. This method differs from the
+    /// `Debug` implementation in that it *does* leak the the struct's
+    /// internal state.
+    pub fn reveal(&self) -> String {
+        format!(
+            "BivarCommitment {{ degree: {}, coeff: {:?} }}",
+            self.degree, self.coeff
+        )
     }
 }
 

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -349,6 +349,14 @@ impl Poly {
         Poly::compute_interpolation(&samples)
     }
 
+    /// Returns the unique polynomial `f` of degree `samples.len() - 1` with the given values
+    /// `(x, f(x))`. Expects samples to be a vector of two tuple Field representation elements.
+    pub fn interpolate_from_fr(samples: Vec<(Fr, Fr)>) -> Self
+    {
+        Poly::compute_interpolation(&samples)
+    }
+
+
     /// Returns the degree.
     pub fn degree(&self) -> usize {
         self.coeff.len().saturating_sub(1)


### PR DESCRIPTION
- Add `reveal` to publickey and bivarcommitment for inspection
- Add `interpolate_from_fr` for directly interpolation a polynomial without conversion to Fr
- Add `with_secret` function to bipoly to construct a bivariate polynomial with a known constant term as the secret value